### PR TITLE
Adding a mention of the assets folder to the migration guide

### DIFF
--- a/docs/deploy-squid/migration.md
+++ b/docs/deploy-squid/migration.md
@@ -77,7 +77,14 @@ scale:
 
 Apply for a Premium account by filling this [form](https://t.ly/Uh_S).
 
-## 5. Create or update the deployment
+## 5. Ensure that the `assets` folder is available
+
+Some older templates did not include this folder but new build scripts require it. If your squid does not have it, run
+```bash
+mkdir assets
+```
+
+## 6. Create or update the deployment
 
 If there is no version `v1` deployed to Aquarium, simply deploy with
 ```bash

--- a/docs/tutorials/create-an-evm-processing-squid.md
+++ b/docs/tutorials/create-an-evm-processing-squid.md
@@ -93,10 +93,11 @@ It's worth noting a couple of things in this [schema definition](https://docs.su
 
 The template already has automatically generated TypeScript classes for this schema definition. They can be found under `src/model/generated`.
 
-Whenever changes are made to the schema, new TypeScript entity classes have to be generated, and to do that you'll have to run the `codegen` tool:
+Whenever changes are made to the schema, new TypeScript entity classes have to be generated and migrations have to be updated. To do that run
 
 ```bash
 make codegen
+make migration
 ```
 
 ## ABI Definition and Wrapper


### PR DESCRIPTION
Simulatneously with the introduction of squid.yaml build scripts began to break in absence of the assets folder. Adding a small extra step to the migration guide to neutralize this issue.

	modified:   docs/deploy-squid/migration.md