### PR TITLE
Merged version of the ABI quickstart

### DIFF
--- a/docs/quickstart/quickstart-abi.md
+++ b/docs/quickstart/quickstart-abi.md
@@ -6,17 +6,18 @@ description: A squid indexing events and txs from an ABI
 
 # Quickstart: generate from ABI
 
-The `abi` template generates a read-to-use squid from an EVM contract ABI. The squid decodes and indexes the EVM logs and transactions of the contract into a local Postgres database. Additionally, it serves the indexed with a rich GraphQL API supporting pagination and filtering. 
+The `abi` template generates a ready-to-use squid from an EVM contract ABI. The squid decodes and indexes EVM logs and transactions of the contract into a local Postgres database. Additionally, it serves the indexed data with a rich GraphQL API supporting pagination and filtering. 
 
 ## Pre-requisites
 
 Before getting to work on your very first squid, verify that you have installed the following software: 
 
-- Node v16.x
-- [Squid CLI](/squid-cli) v^2.1.0
+- Node v16.x or newer
+- [Squid CLI](/squid-cli) v2.1.0 or newer
+- Docker
 
 :::info
-Earlier versions of the template were based on `Makefile`. The new version uses [`@subsquid/commands` scripts](https://github.com/subsquid/squid-sdk/tree/master/util/commands), defined in `commands.json`, that are automatically recognized as `sqd` sub-commands.
+Earlier versions of the template were based on `Makefile`. The new version uses [`@subsquid/commands` scripts](https://github.com/subsquid/squid-sdk/tree/master/util/commands), defined in `commands.json` that are automatically recognized as `sqd` sub-commands.
 :::
 
 Please note:
@@ -36,23 +37,23 @@ npm ci
 
 ##  Step 2: Generate and build the squid
 
-- Consult the [EVM configuration page](/develop-a-squid/evm-processor/configuration) and choose an archive endpoint from the list of the supported EVM networks. 
-- Prepare the contract ABI and save into the `assets` folder, e.g. as `assets/abi.json`
+- Consult the [EVM configuration page](/develop-a-squid/evm-processor/configuration) and choose an archive endpoint from the list of supported EVM networks. 
+- Prepare the contract ABI and save it into the `assets` folder, e.g. as `assets/abi.json`.
 
 :::info
-For public contracts the ABI is fetched automatically using the Etherscan API and the `--abi` flag can be omitted. Run 
+For public contracts the ABI can be fetched automatically using the Etherscan API. To do so simply omit the `--abi` flag. Check out
 ```sh
 sqd generate --help
 ```
-for a full set of supported options.
+for a full list of supported options.
 :::
 
 Generate and build the squid with
 ```bash
-sqd generate -- \
+sqd generate \
 --address <address> \
 --abi assets/abi.json \
---archive <network archive alias> \
+--archive <network archive alias or endpoint URL> \
 --event '*' \
 --function '*' \
 --from <starting block>
@@ -63,16 +64,18 @@ sqd build
 ### Example
 
 ```bash
-npm run generate -- \
+sqd generate \
 --address 0x6B175474E89094C44Da98b954EedeAC495271d0F \
 --abi assets/abi.json \
---archive eth-mainnet \
+--archive https://eth.archive.subsquid.io \
 --event '*' \
 --function '*' \
---from 600000
+--from 1000000
+
+sqd build
 ```
 
-## Step 3: Launch Postgres and detach
+## Step 3: Launch Postgres in a detached Docker container
 
 ```bash
 sqd up
@@ -91,11 +94,11 @@ Run the processor with
 sqd process
 ```
 
- The squid we have just built ingests the transaction and EVM log data emitted by the contract, decodes it and stores into the local Postgres database.
+The squid we have just built now ingests the data on contract transactions and events, decodes it and stores it in the database.
 
 ## Step 6: Start the GraphQL server
 
-This should be run in a separate terminal window:
+In a separate terminal window, run
 
 ```bash
 sqd serve
@@ -103,7 +106,7 @@ sqd serve
 sqd open http://localhost:4350/graphql
 ```
 
-This starts a GraphQL server serving the indexed events and transactions from the local database. The GraphQL playground is available at `http://localhost:4350/graphql`. Open it in a browser and run sample queries by applying filters and data selections in the panel to the left.
+This starts a GraphQL server serving the indexed events and transactions from the local database. The GraphQL playground is available at [`http://localhost:4350/graphql`](http://localhost:4350/graphql). Open it in a browser and run sample queries by applying filters and data selections in the panel to the left.
 
 ```graphql
 query MyQuery {
@@ -114,16 +117,15 @@ query MyQuery {
 }
 ```
 
-## Step 6: Customize
+## Step 7: Customize
 
 [Hack](/develop-a-squid/) the schema file `schema.graphql` and the processor `src/processor.ts` to index the data your way!
 
 ## What's next?
 
-- [Migrate the existing subgraphs to Subsquid](/migrate/migrate-subgraph)
-- [Define your own data schema and the GraphQL API](/develop-a-squid/schema-file)
+- [Migrate your existing subgraphs to Subsquid](/migrate/migrate-subgraph)
+- [Define your own data schema](/develop-a-squid/schema-file)
 - [Explore examples of squids for EVM networks, from simple transfer indexing to DEX analytics](/develop-a-squid/examples)
-- [Define the data schema and serve the data with a GraphQL API](/develop-a-squid/schema-file)
 - [Deeper dive into `EvmBatchProcessor`](/develop-a-squid/evm-processor)
 - [Explore how to enhance the GraphQL API with custom SQL, caching and limits](/develop-a-squid/graphql-api)
 - [Deploy the squid to the Aquarium hosted service](/deploy-squid)


### PR DESCRIPTION
This version is a synthesis of what's currently in master and in develop. Compared to master: typo fixes, (hopefully) improved language in a few places. Compared to develop: a few expanded explanations, master-compatible link paths.

	modified:   docs/quickstart/quickstart-abi.md