### PR TITLE
File-store documentation updates

### DIFF
--- a/docs/basics/store/file-store/csv-table.md
+++ b/docs/basics/store/file-store/csv-table.md
@@ -11,24 +11,26 @@ description: >-
 
 The `@subsquid/file-store-csv` package provides a `Table` implementation for writing to CSV files. Use it by [supplying one or more of its instances via the `tables` field of the `Database` constructor argument](../overview/#database-options). Constructor of the `Table` implementation accepts the following arguments:
 1. **`fileName: string`**: the name of the output file in every dataset partition folder.
-2. **`schema: {[column: string]: Column}`**: a mapping from CSV column names to [`Column` objects](#columns). A mapping of the same keys to data values is the row type used by the [table writer](../overview/#table-writer-interface).
+2. **`schema: {[column: string]: ColumnData}`**: a mapping from CSV column names to [`ColumnData` objects](#columns). A mapping of the same keys to data values is the row type used by the [table writer](../overview/#table-writer-interface).
 3. **`options?: TableOptions`**: see [`Table` Options](#table-options).
 
-## `Column`s
+## Columns
 
-`Column` objects determine how the in-memory data representation of each table column should be serialized. Constructor of `Column`s accepts a column data type and an optional `{nullable?: boolean}` `options` object as arguments.
+`ColumnData` objects determine how the in-memory data representation of each table column should be serialized. They are made with the `Column` factory function that accepts a column data type and an optional `{nullable?: boolean}` `options` object as arguments.
 
 Column types can be obtained by making the function calls listed below from the `Types` submodule. They determine the type that the [table writer](../overview/#table-writer-interface) will expect to find at the corresponding field of data row objects.
 
 | Column type                       | Type of the data row field |
 |:---------------------------------:|:--------------------------:|
 | `Types.String()`                  | `string`                   |
-| `Types.Integer()`                 | `number` or `bigint`       |
-| `Types.Decimal()`                 | `number`                   |
+| `Types.Numeric()`                 | `number` or `bigint`       |
 | `Types.Boolean()`                 | `boolean`                  |
 | `Types.DateTime(format?: string)` | `Date`                     |
+| `Types.JSON<T>()`                 | `T`                        |
 
 `Types.DateTime` accepts an optional [strftime](https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html)-compatible format string. If it is omitted, the dates will be serialized to [ISO strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
+
+The type `T` supplied to the `Types.JSON()` generic function must be an object with string keys (extend `{[k: string]: any}`).
 
 ## `Table` Options
 
@@ -62,7 +64,7 @@ enum Quote {
   MINIMAL,    // Only quote strings with special characters.
               // A special character is one of the following:
               // delimiter, lineterminator, quoteChar.
-  NONNUMERIC, // Quote strings, booleans and Dates.
+  NONNUMERIC, // Quote strings, booleans, DateTimes and JSONs.
   NONE        // Do not quote values.
 }
 ```
@@ -108,7 +110,7 @@ const dbOptions = {
       {
         from: Column(Types.String()),
         to: Column(Types.String()),
-        value: Column(Types.Integer())
+        value: Column(Types.Numeric())
       },
       {
         extension: 'tsv',

--- a/docs/basics/store/file-store/json-table.md
+++ b/docs/basics/store/file-store/json-table.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 40
+title: JSON support
+description: >-
+  Table class for writing JSON and JSONL files
+---
+
+# JSON format support
+
+## `Table` Implementation
+
+The `@subsquid/file-store-json` package provides a `Table` implementation for writing to JSON and [JSONL](https://jsonlines.org) files. Use it by [supplying one or more of its instances via the `tables` field of the `Database` constructor argument](../overview/#database-options). The `Table` uses a constructor with the following signature:
+```typescript
+Table<S extends Record<string, any>>(fileName: string, options?: {lines?: boolean})
+```
+Here,
+1. **`S`** is a Typescript type describing the schema of the table data.
+1. **`fileName: string`** is the name of the output file in every dataset partition folder.
+3. **`options?: {lines?: boolean}`** are table options. At the moment the only available setting is whether to use JSONL instead of a plain JSON array (default: false).
+
+## Example
+
+This saves ERC20 `Transfer` events captured by the processor to a JSONL file where each line is a JSON serialization of a `{from: string, to: string, value: number}` object. Full squid code is available in [this repo](https://github.com/subsquid-labs/file-store-json-example).
+
+```typescript
+import {Database} from '@subsquid/file-store'
+import {Table} from '@subsquid/file-store-json'
+
+...
+
+const dbOptions = {
+  tables: {
+    TransfersTable: new Table<{
+      from: string,
+      to: string,
+      value: bigint
+    }>('transfers.jsonl', { lines: true })
+  },
+  ...
+}
+
+processor.run(new Database(dbOptions), async (ctx) => {
+  ...
+  let from: string = ...
+  let to: string = ...
+  let value: bigint = ...
+  ctx.store.TransfersTable.write({ from, to, value })
+  ...
+})
+```

--- a/docs/basics/store/file-store/overview.md
+++ b/docs/basics/store/file-store/overview.md
@@ -32,7 +32,7 @@ const dbOptions = {
     TransfersTable: new Table('transfers.csv', {
       from: Column(Types.String()),
       to: Column(Types.String()),
-      value: Column(Types.Integer())
+      value: Column(Types.Numeric())
     })
   },
   dest: new LocalDest('./data'),
@@ -94,8 +94,8 @@ DatabaseOptions {
 }
 ```
 Here,
-1. `Table` is an interface for classes that convert in-memory tabular data into format-specific file contents. An implementation of `Table` is available for every file format supported by `file-store`. Consult [documentation pages on support for specific file formats](..) for details.
-2. **`tables`** is a mapping from developer-defined string handles to `Table` instances. A [table writer](#table-writer-interface) will be created for each `Table` in this mapping. It will be exposed at `ctx.store.<tableHandle>`.
+1. `Table` is an interface for classes that make [table writers](#table-writer-interface), objects that convert in-memory tabular data into format-specific file contents. An implementation of `Table` is available for every file format supported by `file-store`. Consult [pages about specific output formats](..) to find out how to define `Table`s.
+2. **`tables`** is a mapping from developer-defined string handles to `Table` instances. A table writer will be created for each `Table` in this mapping. It will be exposed at `ctx.store.<tableHandle>`.
 3. **`dest`** is an instance of `Dest`, an interface for classes that take the properly formatted file contents and write them onto a particular filesystem. An implementation of `Dest` is available for every filesystem supported by `file-store`. For local filesystems use the `LocalDest` class from the `@subsquid/file-store` package and supply `new LocalDest(outputDirectoryName)` here. For other targets consult [documentation pages specific to your filesystem choice](..).
 4. **`chunkSizeMb`**, **`syncIntervalBlocks`** and **`hooks`** are optional parameters that tune the behavior of the [dataset partitioning algorithm](#filesystem-syncs-and-dataset-partitioning).
 
@@ -108,7 +108,7 @@ For each `Table` supplied via the `tables` field of the constructor argument, `D
 
 Here, `T` is a `Table`-specific data row type. See the [documentation pages on support for specific file formats](..) for details.
 
-These synchronous methods add rows of data to an in-memory buffer and perform no actual filesystem writes. Instead, the write [happens automatically when a new dataset partition is created](#filesystem-syncs-and-dataset-partitioning). The methods return the table writer instance and can be chained. 
+These synchronous methods add rows of data to an in-memory buffer and perform no actual filesystem writes. Instead, the write [happens automatically when a new dataset partition is created](#filesystem-syncs-and-dataset-partitioning). The methods return the table writer instance and can be chained.
 
 ## Filesystem Syncs and Dataset Partitioning
 

--- a/docs/basics/store/file-store/s3-dest.md
+++ b/docs/basics/store/file-store/s3-dest.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 40
+sidebar_position: 50
 title: S3 support
 description: >-
   A Dest class for uploading data to buckets


### PR DESCRIPTION
1. Correct the inaccuracy of the Table type story in the overview.
2. Replace Integer with Numeric in all examples.
3. Replace "Dates" with DateTimes in the CSV Quote paragraph
4. @csv @parquet Column->ColumnData. Keep the section URL intact!
7. DOUBLE->Double @parquet
8. Document non-scalar parquet types & CSV jsons (inc the dialect comment)
5. Document file-store-json
6. Replace the default values for rowGroupSize and pageSize on the parquet page

	modified:   docs/basics/store/file-store/csv-table.md
	new file:   docs/basics/store/file-store/json-table.md
	modified:   docs/basics/store/file-store/overview.md
	modified:   docs/basics/store/file-store/parquet-table.md
	modified:   docs/basics/store/file-store/s3-dest.md