### PR TITLE
Replaced the deprecated scaling form links

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ sidebar_position: 130
 
 ### What is the Premium plan?
 
-The access to Archives is free. Aquarium offers a free and a premium plans. The Premium plan is currently available by invite via the [form](https://luvp4va64ru.typeform.com/to/QrRF66q5). When released to the public, Premium will be based on the fixed subscription fee + pay-as-you-go model. Details will be announced in the official Subsquid channels.
+The access to Archives is free. Aquarium offers a free and a premium plans. The Premium plan is currently available by invite via the [form](https://docs.google.com/forms/d/e/1FAIpQLSchqvWxRhlw7yfBlfiudizLJI9hEfeCEuaSlk3wOcwB1HQf6g/viewform?usp=sf_link). When released to the public, Premium will be based on the fixed subscription fee + pay-as-you-go model. Details will be announced in the official Subsquid channels.
 
 ### Do you have a roadmap ?
 

--- a/versioned_docs/version-firesquid/deploy-squid/scale.md
+++ b/versioned_docs/version-firesquid/deploy-squid/scale.md
@@ -6,7 +6,7 @@ description: Scale the squid with the deployment manifest
 
 # Scale the deployment
 
-The `scale:` section of the [deployment manifest](/firesquid/deploy-squid/deploy-manifest) allows allocating additional computing resources for the squid addons and services. This option is only available for Premium Aquarium accounts. To apply for a Premium account, fill the [form](https://luvp4va64ru.typeform.com/to/QrRF66q5).
+The `scale:` section of the [deployment manifest](/firesquid/deploy-squid/deploy-manifest) allows allocating additional computing resources for the squid addons and services. This option is only available for Premium Aquarium accounts. To apply for a Premium account, fill the [form](https://docs.google.com/forms/d/e/1FAIpQLSchqvWxRhlw7yfBlfiudizLJI9hEfeCEuaSlk3wOcwB1HQf6g/viewform?usp=sf_link).
 
 The manifest supports the following scaling options:
 


### PR DESCRIPTION
Found another one in FAQ

	modified:   docs/faq.md
	modified:   versioned_docs/version-firesquid/deploy-squid/scale.md