### PR TITLE
update info about zksync networks

### DIFF
--- a/versioned_docs/version-arrowsquidV0/evm-indexing/supported-networks.mdx
+++ b/versioned_docs/version-arrowsquidV0/evm-indexing/supported-networks.mdx
@@ -55,8 +55,7 @@ The table below lists the currently available public EVM ArrowSquid/v2 Archive e
 | sepolia               | ✓           | ✓      | `lookupArchive('sepolia')`                    |
 | shibuya-testnet (*)   |             |        | `lookupArchive('shibuya-testnet')`            |
 | shiden-mainnet (*)    |             |        | `lookupArchive('shiden-mainnet')`             |
-| zksync-mainnet        |             | ✓      | `lookupArchive('zksync-mainnet')`             |
-| zksync-testnet        |             | ✓      | `lookupArchive('zksync-testnet')`             |
+| zksync-mainnet        |             | <FromBlockTooltip tip="15500000">✓</FromBlockTooltip>      | `lookupArchive('zksync-mainnet')`             |
 | zora-mainnet          | ✓           | ✓      | `lookupArchive('zora-mainnet')`               |
 | zora-goerli           | ✓           | ✓      | `lookupArchive('zora-goerli')`                |
 


### PR DESCRIPTION
i've stopped ingestion for zksync-testnet because the networks isn't active anymore. and all rpc nodes i could find had problems with traces so they were disabled until 15_500_000 block