### PR TITLE
Fix minor typo in "Squid from Scratch"

### DIFF
--- a/docs/sdk/how-to-start/squid-from-scratch.mdx
+++ b/docs/sdk/how-to-start/squid-from-scratch.mdx
@@ -126,7 +126,7 @@ To make the indexer, follow these steps:
        .setGateway(lookupArchive('eth-mainnet'))
        .setRpcEndpoint({
          // set RPC endpoint in .env
-         url: process.env.RPC_ETH_HTTP`,
+         url: process.env.RPC_ETH_HTTP,
          rateLimit: 10
        })
        .setFinalityConfirmation(75) // 15 mins to finality


### PR DESCRIPTION
Removes extra "`" which breaks copy/pasting the example. 