### PR TITLE
Update self-hosting.md with security considerations

### DIFF
--- a/versioned_docs/version-firesquid/deploy-squid/self-hosting.md
+++ b/versioned_docs/version-firesquid/deploy-squid/self-hosting.md
@@ -68,8 +68,6 @@ services:
     environment:
       POSTGRES_DB: squid
       POSTGRES_PASSWORD: postgres
-    ports:
-      - "5432:5432"
       # Uncomment for logging all SQL statements
       # command: ["postgres", "-c", "log_statement=all"]
   api:


### PR DESCRIPTION
It is considered bad security practice if you expose the db port on the host; Both the api, and the processor can access it (because the env variable of DB_HOST is set to db. An alternative would be to specify it in the .env file. If the dev needs access he can always spawn a shell with `docker exec -it <container name> bash`