### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/sdk/resources/substrate/gear.md
+++ b/docs/sdk/resources/substrate/gear.md
@@ -7,7 +7,7 @@ description: >-
 # Gear support
 
 :::info
-SQD Network has gateways for two networks that use Gear Protocol: **Vara** and **Vara Testnet**. Here are their endopint URLs:
+SQD Network has gateways for two networks that use Gear Protocol: **Vara** and **Vara Testnet**. Here are their endpoint URLs:
 ```
 https://v2.archive.subsquid.io/network/vara
 ```

--- a/docs/squid-cli/tags.md
+++ b/docs/squid-cli/tags.md
@@ -1,7 +1,7 @@
 `sqd tags`
 =============
 
-Manage squid deployements' tags. See the [slots and tags guide](/cloud/resources/slots-and-tags).
+Manage squid deployments' tags. See the [slots and tags guide](/cloud/resources/slots-and-tags).
 
 * [`sqd tags add`](#sqd-tags-add)
 * [`sqd tags remove`](#sqd-tags-remove)

--- a/docs/tron-indexing/tron-batch-processor/logs.md
+++ b/docs/tron-indexing/tron-batch-processor/logs.md
@@ -36,7 +36,7 @@ Omit the `where` field to subscribe to all logs network-wide.
 
 **Related data** can be requested via the `include` field:
 
-- `transaction = true`: will retrieve the parent transacton for each selected log.
+- `transaction = true`: will retrieve the parent transaction for each selected log.
 
 The data will be added to the `.transactions` iterable within [block data](/tron-indexing/tron-batch-processor/context-interfaces) and made available via the `.transaction` field of each log item.
 


### PR DESCRIPTION

## Changes Made

### 1. docs/sdk/resources/substrate/gear.md
- Changed "endpint" to "endpoint"
- Line affected: `SQD Network has gateways for two networks that use Gear Protocol: **Vara** and **Vara Testnet**. Here are their endpoint URLs:`

### 2. docs/squid-cli/tags.md
- Changed "deployements" to "deployments"
- Line affected: `Manage squid deployments tags. See the [slots and tags guide](/cloud/resources/slots-and-tags).`

### 3. docs/tron-indexing/tron-batch-processor/logs.md
- Changed "transacton" to "transaction"
- Line affected: `- 'transaction = true': will retrieve the parent transaction for each selected log.`

## Reason for Changes
These changes fix spelling errors in the documentation to improve readability and maintain professional quality. Correct spelling is crucial for:
1. Better user comprehension
2. Maintaining documentation professionalism
3. Avoiding confusion for non-native English speakers
4. Ensuring technical accuracy